### PR TITLE
fixes form submission issue

### DIFF
--- a/allyourreps/src/AddressForm.js
+++ b/allyourreps/src/AddressForm.js
@@ -15,6 +15,7 @@ class AddressForm extends React.Component {
   }
 
   handleFormSubmit(event) {
+    event.preventDefault()
     // onFormSubmit is a parent function
     // we need to pass the address up
     // so the parent can make the API call


### PR DESCRIPTION
Adds an event.preventDefault() call to prevent an issue on mobile where submitting by tapping on an address above the "Find em!" button showed no results.